### PR TITLE
fix: sets ci env var to production during build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,24 +202,26 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test-matrix, security-scan, docker-test]
     if: startsWith(github.ref, 'refs/tags/v')
-    
+
     steps:
       - name: 🔄 Checkout code
         uses: actions/checkout@v4
-        
+
       - name: 📦 Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
-          
+
       - name: 🔧 Install dependencies
         run: npm ci
-        
+
       - name: 🏗️ Build project
         run: npm run build
-        
+        env:
+          NODE_ENV: production
+
       - name: 🚀 Publish to NPM
         run: npm publish --access public
         env:
@@ -270,6 +272,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha, scope=mcp-search
           cache-to: type=gha,mode=max,scope=mcp-search,ignore-error=true
+        env:
+          NODE_ENV: production
 
   # 🎉 Create GitHub Release
   create-release:


### PR DESCRIPTION
Env var defaults to `development` which causes pino-pretty (a dev dep) to throw since is not bundled. The fix sets the node env to `production` for docker and npm 