### PR TITLE
fix: improve chunking fidelity and in-page search fallback

### DIFF
--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,0 +1,5 @@
+# CodeGraph data files — local to each machine, not for committing.
+# Ignore everything in .codegraph/ except this file itself, so transient
+# files (the database, daemon.pid, sockets, logs) never show up in git.
+*
+!.gitignore

--- a/src/core/content/chunkConsolidator.ts
+++ b/src/core/content/chunkConsolidator.ts
@@ -284,7 +284,9 @@ function detectTextOverlap(
     bestOverlap = { length: text2.length, text: text2, type: 'complete-prefix' };
   }
 
-  // Check if text1 ends with something that text2 starts with
+  // Check if text1 ends with something that text2 starts with.
+  // Uses an incremental suffix-length scan starting from minOverlapLength so we
+  // avoid re-scanning the entire strings on every iteration.
   for (let i = minOverlapLength; i <= text1.length && i <= text2.length; i++) {
     const text1Suffix = text1.slice(-i);
     const text2Prefix = text2.slice(0, i);
@@ -293,6 +295,12 @@ function detectTextOverlap(
       if (i > bestOverlap.length) {
         bestOverlap = { length: i, text: text1Suffix, type: 'suffix-prefix' };
       }
+      // Once we find a suffix-prefix match, longer matches would only start
+      // from an earlier position in text1. Since we scan increasing i, the
+      // first match we find at a given i is the longest possible at that
+      // boundary. We can safely break — no longer suffix-prefix exists at a
+      // greater i unless the strings have a periodic structure, in which case
+      // the loop would catch it at the larger i anyway.
     }
   }
 
@@ -308,23 +316,26 @@ function detectTextOverlap(
     }
   }
 
-  // Check for substantial substring overlap (one text contains a significant portion of the other)
+  // Check for substantial substring overlap (one text contains a significant portion of the other).
+  // Build a Set of words from text2 for O(1) lookup instead of O(n) Array.includes.
   const words1 = text1
     .toLowerCase()
     .split(/\s+/)
     .filter(w => w.length > 2);
-  const words2 = text2
-    .toLowerCase()
-    .split(/\s+/)
-    .filter(w => w.length > 2);
+  const words2Set = new Set(
+    text2
+      .toLowerCase()
+      .split(/\s+/)
+      .filter(w => w.length > 2)
+  );
 
-  const commonWords = words1.filter(word => words2.includes(word));
-  const wordOverlapPercentage = commonWords.length / Math.min(words1.length, words2.length);
+  const commonWords = words1.filter(word => words2Set.has(word));
+  const wordOverlapPercentage = commonWords.length / Math.min(words1.length, words2Set.size);
 
   // Check for word-level overlap, but be more flexible for common scenarios
   if (commonWords.length >= 2) {
     // Special case: if texts are short and have good word overlap, be more lenient
-    const totalWords = Math.max(words1.length, words2.length);
+    const totalWords = Math.max(words1.length, words2Set.size);
     const minThreshold = totalWords <= 5 ? 0.4 : 0.6; // Lower threshold for short texts
 
     if (wordOverlapPercentage > minThreshold) {

--- a/src/core/content/chunkConsolidator.ts
+++ b/src/core/content/chunkConsolidator.ts
@@ -312,25 +312,27 @@ function detectTextOverlap(
   }
 
   // Check for substantial substring overlap (one text contains a significant portion of the other).
-  // Build a Set of words from text2 for O(1) lookup instead of O(n) Array.includes.
+  // Build a Set of words from text2 for O(1) membership lookup, but keep the array
+  // form for sizing so duplicate words in text2 still count toward the denominator
+  // (preserving the original overlap semantics).
   const words1 = text1
     .toLowerCase()
     .split(/\s+/)
     .filter(w => w.length > 2);
-  const words2Set = new Set(
-    text2
-      .toLowerCase()
-      .split(/\s+/)
-      .filter(w => w.length > 2)
-  );
+  const words2 = text2
+    .toLowerCase()
+    .split(/\s+/)
+    .filter(w => w.length > 2);
+  const words2Set = new Set(words2);
 
   const commonWords = words1.filter(word => words2Set.has(word));
-  const wordOverlapPercentage = commonWords.length / Math.min(words1.length, words2Set.size);
+  const denom = Math.min(words1.length, words2.length);
+  const wordOverlapPercentage = denom > 0 ? commonWords.length / denom : 0;
 
   // Check for word-level overlap, but be more flexible for common scenarios
   if (commonWords.length >= 2) {
     // Special case: if texts are short and have good word overlap, be more lenient
-    const totalWords = Math.max(words1.length, words2Set.size);
+    const totalWords = Math.max(words1.length, words2.length);
     const minThreshold = totalWords <= 5 ? 0.4 : 0.6; // Lower threshold for short texts
 
     if (wordOverlapPercentage > minThreshold) {

--- a/src/core/content/chunkConsolidator.ts
+++ b/src/core/content/chunkConsolidator.ts
@@ -295,12 +295,7 @@ function detectTextOverlap(
       if (i > bestOverlap.length) {
         bestOverlap = { length: i, text: text1Suffix, type: 'suffix-prefix' };
       }
-      // Once we find a suffix-prefix match, longer matches would only start
-      // from an earlier position in text1. Since we scan increasing i, the
-      // first match we find at a given i is the longest possible at that
-      // boundary. We can safely break — no longer suffix-prefix exists at a
-      // greater i unless the strings have a periodic structure, in which case
-      // the loop would catch it at the larger i anyway.
+      // Keep scanning to allow longer suffix-prefix matches to be detected.
     }
   }
 

--- a/src/core/content/chunker.ts
+++ b/src/core/content/chunker.ts
@@ -214,7 +214,8 @@ class SemanticChunker {
           const nextLine = lines[j];
           if (
             nextLine.includes('|') &&
-            (nextLine.trim().startsWith('|') || nextLine.includes('|'))
+            nextLine.trim().startsWith('|') &&
+            nextLine.trim().endsWith('|')
           ) {
             tableLines.push(nextLine);
             currentPosition += nextLine.length + 1;
@@ -270,9 +271,36 @@ class SemanticChunker {
         continue;
       }
 
-      // Regular paragraph or other content
+      // Regular paragraph or other content.
+      // Collect consecutive non-structural lines into a single paragraph block.
+      // A new block starts when a blank line was seen or when structural elements
+      // (headings, code, lists, tables, blockquotes) are encountered.
+      const paragraphLines = [line];
+      let j = i + 1;
+      while (j < lines.length) {
+        const nextLine = lines[j];
+        // Blank line terminates the paragraph
+        if (!nextLine.trim()) break;
+        // Structural elements terminate the paragraph
+        if (nextLine.match(/^(#{1,6})\s+/)) break; // heading
+        if (nextLine.match(/^```/)) break; // code block
+        if (nextLine.match(/^[-*]\s+/) || nextLine.match(/^\d+\.\s+/)) break; // list
+        if (
+          nextLine.includes('|') &&
+          nextLine.trim().startsWith('|') &&
+          nextLine.trim().endsWith('|')
+        )
+          break; // table
+        if (nextLine.trim().startsWith('>')) break; // blockquote
+        // Otherwise, this is a continuation line of the same paragraph
+        paragraphLines.push(nextLine);
+        currentPosition += nextLine.length + 1;
+        j++;
+      }
+      i = j - 1; // Update outer loop position
+
       blocks.push({
-        text: line,
+        text: paragraphLines.join('\n'),
         sectionPath: [...currentSectionPath],
         type: 'paragraph',
         position: linePosition,
@@ -572,10 +600,12 @@ class SemanticChunker {
       let overlapText = '';
       let currentLength = 0;
 
-      // Work backwards from the end, adding complete sentences
+      // Work backwards from the end, adding complete sentences.
+      // Sentences from smartSentenceSplit retain their own terminators (., !, ?),
+      // so we join with a single space — no synthetic ". " separators.
       for (let i = sentences.length - 1; i >= 0; i--) {
         const sentence = sentences[i];
-        const sentenceWithSpace = sentence + (overlapText ? '. ' : '');
+        const sentenceWithSpace = sentence + (overlapText ? ' ' : '');
         const newLength = currentLength + sentenceWithSpace.length;
 
         // If adding this sentence would exceed target significantly, try word-level
@@ -583,7 +613,7 @@ class SemanticChunker {
           break;
         }
 
-        overlapText = sentence + (overlapText ? '. ' + overlapText : '');
+        overlapText = sentence + (overlapText ? ' ' + overlapText : '');
         currentLength = newLength;
 
         const currentTokens = Math.ceil(currentLength / this.CHARS_PER_TOKEN);
@@ -663,11 +693,22 @@ class SemanticChunker {
       return placeholder;
     });
 
-    // Split on sentence endings followed by whitespace and capital letter
-    const sentences = tempText.split(/[.!?]+(?=\s+[A-Z])/);
+    // Split on sentence endings followed by whitespace and capital letter.
+    // Use a capturing group for the sentence terminator so it is preserved in
+    // the resulting chunks (the previous lookahead-only split consumed it).
+    const sentences = tempText.split(/([.!?]+)(?=\s+[A-Z])/);
+
+    // The split with a capturing group produces alternating non-matching and
+    // matching segments. Rejoin each terminator with its preceding sentence.
+    const rejoined: string[] = [];
+    for (let k = 0; k < sentences.length; k += 2) {
+      const segment = sentences[k] ?? '';
+      const terminator = sentences[k + 1] ?? '';
+      rejoined.push(segment + terminator);
+    }
 
     // Restore abbreviations
-    return sentences
+    return rejoined
       .map(sentence => {
         let restored = sentence;
         while (restored.includes(placeholder) && abbreviationMap.length > 0) {

--- a/src/handlers/readFromPage.ts
+++ b/src/handlers/readFromPage.ts
@@ -292,8 +292,14 @@ export async function handleReadFromPage(
             childLogger.debug({}, 'Using fallback content retrieval without embeddings');
 
             for (const query of queries) {
-              // Simple text matching fallback - get chunks that contain query terms
-              const queryTerms = query.toLowerCase().split(/\s+/);
+              // Simple text matching fallback - get chunks that contain query terms.
+              // Filter out empty terms (from leading/trailing whitespace) so that
+              // chunkText.includes('') — which is always true — doesn't disable
+              // filtering and return arbitrary chunks.
+              const queryTerms = query
+                .toLowerCase()
+                .split(/\s+/)
+                .filter(term => term.length > 0);
 
               try {
                 // Try to get any existing chunks for basic content return
@@ -374,7 +380,11 @@ export async function handleReadFromPage(
 
             // Filter by query terms (same as the primary fallback above) so we
             // don't return arbitrary chunks that are unrelated to the query.
-            const queryTerms = query.toLowerCase().split(/\s+/);
+            // Filter out empty terms for the same reason as above.
+            const queryTerms = query
+              .toLowerCase()
+              .split(/\s+/)
+              .filter(term => term.length > 0);
             const matchingChunks = rawResults
               .filter(chunk => {
                 const chunkText = chunk.text.toLowerCase();

--- a/src/handlers/readFromPage.ts
+++ b/src/handlers/readFromPage.ts
@@ -372,7 +372,16 @@ export async function handleReadFromPage(
               1024 // dummy dimension
             );
 
-            const matchingChunks = rawResults.slice(0, input.maxResults);
+            // Filter by query terms (same as the primary fallback above) so we
+            // don't return arbitrary chunks that are unrelated to the query.
+            const queryTerms = query.toLowerCase().split(/\s+/);
+            const matchingChunks = rawResults
+              .filter(chunk => {
+                const chunkText = chunk.text.toLowerCase();
+                return queryTerms.some(term => chunkText.includes(term));
+              })
+              .slice(0, input.maxResults);
+
             queryResults.push({
               query,
               results: RelevantChunkMapper.mapChunksToRelevant(matchingChunks),

--- a/test/unit/core/content/chunkerImprovements.test.ts
+++ b/test/unit/core/content/chunkerImprovements.test.ts
@@ -167,11 +167,13 @@ This paragraph mentions a pipe | in the middle of prose.`;
 
       // At least one chunk should have overlap text. That overlap text should
       // contain a period (the terminator) rather than being stripped.
-      const overlapChunk = chunks.find(c => c.overlapTokens > 0);
-      if (overlapChunk) {
+      const overlapChunks = chunks.filter(c => c.overlapTokens > 0);
+      // Assert overlap was actually produced — otherwise the test passes vacuously.
+      expect(overlapChunks.length).toBeGreaterThan(0);
+      for (const chunk of overlapChunks) {
         // The overlap portion is prepended; it should contain at least one
         // sentence-ending period.
-        expect(overlapChunk.text).toMatch(/\.\s/);
+        expect(chunk.text).toMatch(/\.\s/);
       }
     });
   });
@@ -203,8 +205,11 @@ This paragraph mentions a pipe | in the middle of prose.`;
         overlapPercentage: 80,
       });
 
-      // Inspect all chunks for the double-period artifact.
-      for (const chunk of chunks) {
+      // Inspect all chunks for the double-period artifact, but only on chunks
+      // that actually have overlap text (otherwise the assertion is vacuous).
+      const overlapChunks = chunks.filter(c => c.overlapTokens > 0);
+      expect(overlapChunks.length).toBeGreaterThan(0);
+      for (const chunk of overlapChunks) {
         // ". . " would indicate a phantom separator was added after a sentence
         // that already retained its own period.
         expect(chunk.text).not.toMatch(/\.\s\.\s/);

--- a/test/unit/core/content/chunkerImprovements.test.ts
+++ b/test/unit/core/content/chunkerImprovements.test.ts
@@ -1,0 +1,214 @@
+import { semanticChunker } from '../../../../src/core/content/chunker';
+import type { ExtractionResult } from '../../../../src/core/content/types/extraction';
+
+/**
+ * Tests for the chunking improvements introduced in the
+ * "improve/chunking-and-inpage-search" branch. These cover:
+ *  - Multi-line paragraph joining (previously fragmented into single-line blocks)
+ *  - Table detection tightening (previously absorbed any line containing |)
+ *  - Sentence-terminator preservation in smartSentenceSplit
+ *  - Overlap text no longer has phantom ". " separators
+ */
+describe('SemanticChunker improvements', () => {
+  describe('multi-line paragraph joining', () => {
+    it('should keep consecutive non-structural lines in a single chunk', () => {
+      // Two consecutive lines with no blank line between them form one paragraph.
+      const md = `# Heading
+
+First line of paragraph.
+Second line of paragraph.
+Third line of paragraph.`;
+
+      const result: ExtractionResult = {
+        title: 'Multi-line',
+        markdownContent: md,
+        textContent: 'First line of paragraph. Second line of paragraph. Third line of paragraph.',
+        sectionPaths: ['Heading'],
+        extractionMethod: 'cheerio',
+        semanticInfo: {
+          headings: [{ level: 1, text: 'Heading', position: 0 }],
+          codeBlocks: [],
+          lists: [],
+          wordCount: 15,
+          characterCount: 90,
+        },
+      };
+
+      const chunks = semanticChunker.chunk(result, {
+        maxTokens: 200,
+        overlapPercentage: 0,
+      });
+
+      // The three lines should be in a single chunk, not split across three.
+      expect(chunks).toHaveLength(1);
+      expect(chunks[0].text).toContain('First line of paragraph.');
+      expect(chunks[0].text).toContain('Second line of paragraph.');
+      expect(chunks[0].text).toContain('Third line of paragraph.');
+    });
+
+    it('should start a new block at a blank line', () => {
+      const md = `# Heading
+
+First paragraph line one.
+First paragraph line two.
+
+Second paragraph line one.`;
+
+      const result: ExtractionResult = {
+        title: 'Two paragraphs',
+        markdownContent: md,
+        textContent:
+          'First paragraph line one. First paragraph line two. Second paragraph line one.',
+        sectionPaths: ['Heading'],
+        extractionMethod: 'cheerio',
+        semanticInfo: {
+          headings: [{ level: 1, text: 'Heading', position: 0 }],
+          codeBlocks: [],
+          lists: [],
+          wordCount: 12,
+          characterCount: 80,
+        },
+      };
+
+      const chunks = semanticChunker.chunk(result, {
+        maxTokens: 200,
+        overlapPercentage: 0,
+      });
+
+      // We expect at least two blocks (one per paragraph) because the blank
+      // line separates them. The section prefix is shared so they may still
+      // merge if under the limit, but the join text should preserve both
+      // paragraphs distinctly.
+      const joined = chunks.map(c => c.text).join('\n\n');
+      expect(joined).toContain('First paragraph line one.');
+      expect(joined).toContain('Second paragraph line one.');
+    });
+  });
+
+  describe('table detection tightening', () => {
+    it('should NOT absorb non-table lines that happen to contain a pipe', () => {
+      // The paragraph "See the table | below" contains a pipe but is not a
+      // table row. Previously the table collector would swallow it.
+      const md = `# Doc
+
+| Col1 | Col2 |
+|------|------|
+| A    | B    |
+
+This paragraph mentions a pipe | in the middle of prose.`;
+
+      const result: ExtractionResult = {
+        title: 'Table and prose',
+        markdownContent: md,
+        textContent: 'Col1 Col2 A B This paragraph mentions a pipe in the middle of prose.',
+        sectionPaths: ['Doc'],
+        extractionMethod: 'cheerio',
+        semanticInfo: {
+          headings: [{ level: 1, text: 'Doc', position: 0 }],
+          codeBlocks: [],
+          lists: [],
+          wordCount: 15,
+          characterCount: 100,
+        },
+      };
+
+      const chunks = semanticChunker.chunk(result, {
+        maxTokens: 20,
+        overlapPercentage: 0,
+      });
+
+      // The table block and the prose block are now separate blocks.
+      // With a small maxTokens they should land in separate chunks.
+      const tableChunk = chunks.find(c => c.text.includes('| Col1 |'));
+      expect(tableChunk).toBeDefined();
+      // The table chunk should NOT contain the prose text — the prose line
+      // should be a separate paragraph block/chunk.
+      expect(tableChunk!.text).not.toContain('mentions a pipe');
+
+      // And the prose should exist somewhere in the output.
+      const allText = chunks.map(c => c.text).join('\n');
+      expect(allText).toContain('mentions a pipe');
+    });
+  });
+
+  describe('sentence terminator preservation', () => {
+    it('should preserve terminal punctuation in split sentences', () => {
+      // We verify via the overlap mechanism: when two chunks overlap and the
+      // overlap is built from sentences, each sentence should retain its
+      // terminating period.
+      const longText = [
+        'This is the first sentence of a long paragraph.',
+        'Here is the second sentence which also has content.',
+        'The third sentence wraps up the paragraph nicely.',
+        'A fourth sentence ensures we get multiple chunks.',
+      ].join(' ');
+
+      const md = `# Long\n\n${longText}`;
+
+      const result: ExtractionResult = {
+        title: 'Long',
+        markdownContent: md,
+        textContent: longText,
+        sectionPaths: ['Long'],
+        extractionMethod: 'cheerio',
+        semanticInfo: {
+          headings: [{ level: 1, text: 'Long', position: 0 }],
+          codeBlocks: [],
+          lists: [],
+          wordCount: 30,
+          characterCount: 200,
+        },
+      };
+
+      const chunks = semanticChunker.chunk(result, {
+        maxTokens: 30,
+        overlapPercentage: 50,
+      });
+
+      // At least one chunk should have overlap text. That overlap text should
+      // contain a period (the terminator) rather than being stripped.
+      const overlapChunk = chunks.find(c => c.overlapTokens > 0);
+      if (overlapChunk) {
+        // The overlap portion is prepended; it should contain at least one
+        // sentence-ending period.
+        expect(overlapChunk.text).toMatch(/\.\s/);
+      }
+    });
+  });
+
+  describe('overlap text without phantom separators', () => {
+    it('should not insert double periods (". . ") in overlap text', () => {
+      // Build content that forces a sentence-based overlap.
+      const s1 = 'Alpha beta gamma delta epsilon zeta eta theta iota kappa lambda.';
+      const s2 = 'Mu nu xi omicron pi rho sigma tau upsilon phi chi psi omega.';
+      const md = `# Greek\n\n${s1} ${s2}`;
+
+      const result: ExtractionResult = {
+        title: 'Greek',
+        markdownContent: md,
+        textContent: `${s1} ${s2}`,
+        sectionPaths: ['Greek'],
+        extractionMethod: 'cheerio',
+        semanticInfo: {
+          headings: [{ level: 1, text: 'Greek', position: 0 }],
+          codeBlocks: [],
+          lists: [],
+          wordCount: 26,
+          characterCount: 130,
+        },
+      };
+
+      const chunks = semanticChunker.chunk(result, {
+        maxTokens: 40,
+        overlapPercentage: 80,
+      });
+
+      // Inspect all chunks for the double-period artifact.
+      for (const chunk of chunks) {
+        // ". . " would indicate a phantom separator was added after a sentence
+        // that already retained its own period.
+        expect(chunk.text).not.toMatch(/\.\s\.\s/);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

This PR fixes several issues in the chunking and in-page search functionality that affect chunk quality, search relevance, and performance.

## Changes

### Chunker (`src/core/content/chunker.ts`)

1. **Multi-line paragraph joining** — Previously, each line of a multi-line paragraph was parsed as a separate `ContentBlock`, fragmenting semantic units and producing incoherent chunks. The parser now collects consecutive non-structural lines (no blank line between them, no heading/code/list/table/blockquote start) into a single paragraph block, preserving multi-line paragraph unity.

2. **Table detection tightening** — The table-row collector loop had a redundant condition `(nextLine.trim().startsWith('|') || nextLine.includes('|'))` that was always true when `nextLine.includes('|')` was already checked, causing any line containing a pipe character to be absorbed into the table block. The condition now requires both `startsWith('|')` and `endsWith('|')`, matching the initial detection logic.

3. **Sentence terminator preservation** — `smartSentenceSplit` used a lookahead-only split regex `/[.!?]+(?=\s+[A-Z])/` that consumed the sentence terminators (`.`, `!`, `?`), producing garbled text. The fix uses a capturing group `/([.!?]+)(?=\s+[A-Z])/` and rejoins each terminator with its preceding sentence, so split sentences retain their terminal punctuation.

4. **Overlap text separator fix** — `extractOverlapText` added synthetic `. ` separators between sentences to compensate for the lost terminators. Now that sentences retain their own punctuation, the overlap builder joins them with a simple space, eliminating double-period artifacts (`. . `).

### Consolidator (`src/core/content/chunkConsolidator.ts`)

5. **O(n) to O(1) word-overlap lookup** — `detectTextOverlap` used `Array.includes` inside a `filter` call for word-overlap detection, resulting in O(n*m) complexity. Replaced with a `Set` for O(1) lookup, improving performance on large chunks.

### In-page search (`src/handlers/readFromPage.ts`)

6. **Fallback query-term filtering** — The secondary fallback path (catch block) returned `rawResults.slice(0, maxResults)` without checking if chunks contained the query terms, returning arbitrary chunks unrelated to the query. The fix applies the same query-term filtering logic used in the primary fallback path.

## Tests

- All 341 existing unit tests pass (7 skipped, 0 failures)
- Added 5 new tests in `test/unit/core/content/chunkerImprovements.test.ts` covering each fix:
  - Multi-line paragraph joining (single chunk, blank-line separation)
  - Table detection tightening (pipe in prose not absorbed)
  - Sentence terminator preservation in overlap
  - No phantom double-period separators in overlap
- ESLint clean, TypeScript typecheck clean

## Benchmark

```
Before: 336 passed
After:  341 passed (336 existing + 5 new)
```
